### PR TITLE
Make 'annotations' parameter nullable

### DIFF
--- a/src/main/java/com/jakewharton/rs/kotlinx/serialization/KotlinxSerializationMessageBodyReader.kt
+++ b/src/main/java/com/jakewharton/rs/kotlinx/serialization/KotlinxSerializationMessageBodyReader.kt
@@ -29,7 +29,7 @@ private class StringFormatMessageBodyReader(
   override fun isReadable(
     type: Class<*>,
     genericType: Type,
-    annotations: Array<out Annotation>,
+    annotations: Array<out Annotation>?,
     mediaType: MediaType
   ): Boolean {
     return mediaType in mediaTypes
@@ -38,7 +38,7 @@ private class StringFormatMessageBodyReader(
   override fun readFrom(
     type: Class<Any>,
     genericType: Type,
-    annotations: Array<out Annotation>,
+    annotations: Array<out Annotation>?,
     mediaType: MediaType,
     httpHeaders: MultivaluedMap<String, String>,
     entityStream: InputStream
@@ -70,7 +70,7 @@ private class BinaryFormatMessageBodyReader(
   override fun readFrom(
     type: Class<Any>,
     genericType: Type,
-    annotations: Array<out Annotation>,
+    annotations: Array<out Annotation>?,
     mediaType: MediaType,
     httpHeaders: MultivaluedMap<String, String>,
     entityStream: InputStream

--- a/src/main/java/com/jakewharton/rs/kotlinx/serialization/KotlinxSerializationMessageBodyWriter.kt
+++ b/src/main/java/com/jakewharton/rs/kotlinx/serialization/KotlinxSerializationMessageBodyWriter.kt
@@ -29,7 +29,7 @@ private class StringFormatMessageBodyWriter(
   override fun isWriteable(
     type: Class<*>,
     genericType: Type,
-    annotations: Array<out Annotation>,
+    annotations: Array<out Annotation>?,
     mediaType: MediaType
   ): Boolean {
     return mediaType in mediaTypes
@@ -39,7 +39,7 @@ private class StringFormatMessageBodyWriter(
     value: Any,
     type: Class<*>,
     genericType: Type,
-    annotations: Array<out Annotation>,
+    annotations: Array<out Annotation>?,
     mediaType: MediaType,
     httpHeaders: MultivaluedMap<String, Any>,
     entityStream: OutputStream
@@ -62,7 +62,7 @@ private class BinaryFormatMessageBodyWriter(
   override fun isWriteable(
     type: Class<*>,
     genericType: Type,
-    annotations: Array<out Annotation>,
+    annotations: Array<out Annotation>?,
     mediaType: MediaType
   ): Boolean {
     return mediaType in mediaTypes
@@ -72,7 +72,7 @@ private class BinaryFormatMessageBodyWriter(
     value: Any,
     type: Class<*>,
     genericType: Type,
-    annotations: Array<out Annotation>,
+    annotations: Array<out Annotation>?,
     mediaType: MediaType,
     httpHeaders: MultivaluedMap<String, Any>,
     entityStream: OutputStream


### PR DESCRIPTION
At least in ReastEasy:4.0.0.Beta8 JAX-RS implementation, if you pass an *unsupported* Content-Type on a request (like `application/octet-stream`), instead of getting the right message, the issue es masked with:
```
java.lang.IllegalArgumentException: Parameter specified as non-null is null: method com.jakewharton.rs.kotlinx.serialization.StringFormatMessageBodyWriter.isWriteable, parameter annotations
	at com.jakewharton.rs.kotlinx.serialization.StringFormatMessageBodyWriter.isWriteable(KotlinxSerializationMessageBodyWriter.kt)
	at org.jboss.resteasy.core.ResteasyProviderFactoryImpl.getPossibleMessageBodyWritersMap(ResteasyProviderFactoryImpl.java:2093)
```

In this scenario, `annotations` yelds `null` as you can see here:
![image](https://user-images.githubusercontent.com/513566/55838345-2b817280-5af2-11e9-9160-c449e164e172.png)

Making `annotations` a nullable parameter will allow the code to run and let the JAX-RS provider to handle it