### PR TITLE
Make 'genericType' parameter nullable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,18 @@
 buildscript {
+  ext.kotlin_version = '1.3.30'
   repositories {
     mavenCentral()
   }
 
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.30'
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
   }
 }
 
 apply plugin: 'java-library'
 apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'kotlinx-serialization'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
@@ -20,9 +23,13 @@ repositories {
 }
 
 dependencies {
-  implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.3.30'
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   api 'org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.11.0'
   api 'javax.ws.rs:javax.ws.rs-api:2.1.1'
+  testImplementation 'junit:junit:4.12'
+  testImplementation 'org.jboss.resteasy:resteasy-netty4:4.0.0.CR2'
+  testImplementation 'org.glassfish.jersey.containers:jersey-container-netty-http:2.28'
+  testImplementation 'org.glassfish.jersey.inject:jersey-hk2:2.28'
 }
 
 group = GROUP

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
 apply plugin: 'java-library'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'kotlinx-serialization'
+apply plugin: 'jacoco'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
@@ -30,6 +31,18 @@ dependencies {
   testImplementation 'org.jboss.resteasy:resteasy-netty4:4.0.0.CR2'
   testImplementation 'org.glassfish.jersey.containers:jersey-container-netty-http:2.28'
   testImplementation 'org.glassfish.jersey.inject:jersey-hk2:2.28'
+}
+
+jacoco {
+  toolVersion = '0.8.3'
+}
+
+tasks.withType(JacocoReport.class) {
+  reports {
+    xml.enabled = true
+    html.enabled = true
+  }
+  check.dependsOn(it)
 }
 
 group = GROUP

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/jakewharton/rs/kotlinx/serialization/KotlinxSerializationMessageBodyReader.kt
+++ b/src/main/java/com/jakewharton/rs/kotlinx/serialization/KotlinxSerializationMessageBodyReader.kt
@@ -28,7 +28,7 @@ private class StringFormatMessageBodyReader(
 ) : MessageBodyReader<Any> {
   override fun isReadable(
     type: Class<*>,
-    genericType: Type,
+    genericType: Type?,
     annotations: Array<out Annotation>?,
     mediaType: MediaType
   ): Boolean {
@@ -37,7 +37,7 @@ private class StringFormatMessageBodyReader(
 
   override fun readFrom(
     type: Class<Any>,
-    genericType: Type,
+    genericType: Type?,
     annotations: Array<out Annotation>?,
     mediaType: MediaType,
     httpHeaders: MultivaluedMap<String, String>,
@@ -50,7 +50,7 @@ private class StringFormatMessageBodyReader(
     } ?: Charsets.UTF_8
 
     val string = entityStream.readBytes().toString(charset) // Not closing per parameter Javadoc.
-    return format.parse(serializerByTypeToken(genericType), string)
+    return format.parse(serializerByTypeToken(genericType ?: type), string)
   }
 }
 
@@ -69,13 +69,13 @@ private class BinaryFormatMessageBodyReader(
 
   override fun readFrom(
     type: Class<Any>,
-    genericType: Type,
+    genericType: Type?,
     annotations: Array<out Annotation>?,
     mediaType: MediaType,
     httpHeaders: MultivaluedMap<String, String>,
     entityStream: InputStream
   ): Any {
     val bytes = entityStream.readBytes() // Not closing per parameter Javadoc.
-    return format.load(serializerByTypeToken(genericType), bytes)
+    return format.load(serializerByTypeToken(genericType ?: type), bytes)
   }
 }

--- a/src/main/java/com/jakewharton/rs/kotlinx/serialization/KotlinxSerializationMessageBodyWriter.kt
+++ b/src/main/java/com/jakewharton/rs/kotlinx/serialization/KotlinxSerializationMessageBodyWriter.kt
@@ -28,7 +28,7 @@ private class StringFormatMessageBodyWriter(
 ) : MessageBodyWriter<Any> {
   override fun isWriteable(
     type: Class<*>,
-    genericType: Type,
+    genericType: Type?,
     annotations: Array<out Annotation>?,
     mediaType: MediaType
   ): Boolean {
@@ -38,13 +38,13 @@ private class StringFormatMessageBodyWriter(
   override fun writeTo(
     value: Any,
     type: Class<*>,
-    genericType: Type,
+    genericType: Type?,
     annotations: Array<out Annotation>?,
     mediaType: MediaType,
     httpHeaders: MultivaluedMap<String, Any>,
     entityStream: OutputStream
   ) {
-    val string = format.stringify(serializerByTypeToken(genericType), value)
+    val string = format.stringify(serializerByTypeToken(genericType ?: type), value)
     val charset = try {
       mediaType.parameters["charset"]?.let(Charset::forName)
     } catch (e: RuntimeException) {
@@ -61,7 +61,7 @@ private class BinaryFormatMessageBodyWriter(
 ) : MessageBodyWriter<Any> {
   override fun isWriteable(
     type: Class<*>,
-    genericType: Type,
+    genericType: Type?,
     annotations: Array<out Annotation>?,
     mediaType: MediaType
   ): Boolean {
@@ -71,13 +71,13 @@ private class BinaryFormatMessageBodyWriter(
   override fun writeTo(
     value: Any,
     type: Class<*>,
-    genericType: Type,
+    genericType: Type?,
     annotations: Array<out Annotation>?,
     mediaType: MediaType,
     httpHeaders: MultivaluedMap<String, Any>,
     entityStream: OutputStream
   ) {
-    val bytes = format.dump(serializerByTypeToken(genericType), value)
+    val bytes = format.dump(serializerByTypeToken(genericType ?: type), value)
     entityStream.write(bytes) // Not closing per parameter Javadoc.
   }
 }

--- a/src/test/java/com/jakewharton/rs/kotlinx/serialization/KotlinxSerializationMessageBodyITTest.kt
+++ b/src/test/java/com/jakewharton/rs/kotlinx/serialization/KotlinxSerializationMessageBodyITTest.kt
@@ -1,0 +1,153 @@
+@file:JvmName("KotlinxSerializationMessageBodyReader")
+
+package com.jakewharton.rs.kotlinx.serialization
+
+import org.glassfish.hk2.utilities.binding.AbstractBinder
+import org.glassfish.jersey.client.ClientConfig
+import org.glassfish.jersey.netty.httpserver.NettyHttpContainerProvider
+import org.glassfish.jersey.server.ResourceConfig
+import org.jboss.resteasy.core.NoMessageBodyWriterFoundFailure
+import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.lang.IllegalStateException
+import java.lang.RuntimeException
+import java.net.ServerSocket
+import java.net.URI
+import javax.ws.rs.client.ClientBuilder
+import javax.ws.rs.client.WebTarget
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+import javax.ws.rs.core.UriBuilder
+
+/**
+ * This test cover Serialization/Deserialization from both sides, by raising up a local JAX-RS server (which encodes JSON),
+ * and consuming some APIs with a client (by decoding JSON).
+ */
+@RunWith(Parameterized::class)
+class KotlinxSerializationMessageBodyITTest(private val provider: Provider) {
+
+    private val client = ClientBuilder.newClient(ClientConfig(jsonMessageBodyReader, jsonMessageBodyWriter))
+
+    private val port = ServerSocket(0).apply { close() }.localPort
+
+    private val resourceUri = UriBuilder
+            .fromUri("http://localhost:$port/")
+            .path(TestResource::class.java)
+
+    private lateinit var onStopServer: () -> Unit
+
+    @Test
+    fun testGetById() {
+        val targetUser = testUsersList.first()
+
+        val response: User? = client.target(resourceUri.path(targetUser.id.toString())).execute().entity()
+
+        assertEquals(targetUser, response)
+        assertTrue(targetUser !== response)
+    }
+
+    @Test
+    fun testList() {
+        val response: Array<User> = client.target(resourceUri).execute().entity()
+
+        assertEquals(testUsersList, response.toList())
+    }
+
+    @Test
+    fun testNotFound() {
+        val response = client.target(resourceUri.path("unknown/api"))
+                .execute(assureOk = false)
+
+        assertEquals(Response.Status.NOT_FOUND, response.statusInfo)
+        assertEquals(Response.Status.NOT_FOUND.statusCode, response.entity<ErrorMessage>().errorCode)
+    }
+
+    @Test
+    fun testNotAcceptable() {
+        val response = client.target(resourceUri)
+                .execute(assureOk = false, accept = MediaType.APPLICATION_OCTET_STREAM_TYPE)
+
+        assertEquals(Response.Status.NOT_ACCEPTABLE, response.statusInfo)
+        assertFalse(response.hasEntity())
+        assertNotEquals(MediaType.APPLICATION_JSON, response.mediaType)
+    }
+
+    @Test
+    fun testExceptionThrown() {
+        val response = client.target(resourceUri.path("fail"))
+                .execute(assureOk = false)
+
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR, response.statusInfo)
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.statusCode, response.entity<ErrorMessage>().errorCode)
+    }
+
+    @Before
+    fun startServer() {
+        onStopServer = provider.start(port)
+
+        println("$provider server running at http://localhost:$port")
+    }
+
+    @After
+    fun stopServer() {
+        onStopServer()
+    }
+
+    companion object {
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun data() = Provider.values().map {
+            arrayOf(it)
+        }
+
+    }
+
+    enum class Provider {
+
+        JERSEY {
+            override fun start(port: Int): () -> Unit = NettyHttpContainerProvider
+                    .createHttp2Server(
+                            URI.create("http://localhost:$port/"),
+                            ResourceConfig.forApplication(TestApp()),
+                            null)
+                    .let { { it.close().await() } }
+        },
+
+        RESTEASY {
+            override fun start(port: Int) = NettyJaxrsServer()
+                    .apply {
+                        deployment.application = TestApp()
+                        this.port = port
+                        start()
+                    }::stop
+        };
+
+        abstract fun start(port: Int): () -> Unit
+
+        override fun toString() = name.toLowerCase()
+
+    }
+
+    private fun WebTarget.execute(
+            assureOk: Boolean = true,
+            accept: MediaType = MediaType.APPLICATION_JSON_TYPE) = request()
+            .accept(accept)
+            .buildGet()
+            .invoke()
+            .apply { if (assureOk && status != Response.Status.OK.statusCode) throw ClientHttpException(uri, statusInfo) }
+
+    private inline fun <reified T> Response.entity() = readEntity(T::class.java)
+
+    class ClientHttpException(uri: URI, status: Response.StatusType)
+        : RuntimeException("$uri ${status.statusCode} ${status.reasonPhrase}")
+
+}

--- a/src/test/java/com/jakewharton/rs/kotlinx/serialization/TestJAXRSApp.kt
+++ b/src/test/java/com/jakewharton/rs/kotlinx/serialization/TestJAXRSApp.kt
@@ -1,0 +1,73 @@
+package com.jakewharton.rs.kotlinx.serialization
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.jboss.resteasy.core.NoMessageBodyWriterFoundFailure
+import java.lang.UnsupportedOperationException
+import javax.ws.rs.ApplicationPath
+import javax.ws.rs.GET
+import javax.ws.rs.NotAcceptableException
+import javax.ws.rs.Path
+import javax.ws.rs.PathParam
+import javax.ws.rs.Produces
+import javax.ws.rs.WebApplicationException
+import javax.ws.rs.core.Application
+import javax.ws.rs.core.HttpHeaders
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+import javax.ws.rs.ext.ExceptionMapper
+import javax.ws.rs.ext.Provider
+
+val jsonMessageBodyReader = Json.asMessageBodyReader(MediaType.APPLICATION_JSON_TYPE)
+
+val jsonMessageBodyWriter = Json.asMessageBodyWriter(MediaType.APPLICATION_JSON_TYPE)
+
+val testUsersList = listOf(User(1, "John"), User(2, "Mary"))
+
+class TestApp : Application() {
+
+    override fun getSingletons() = setOf(jsonMessageBodyReader, jsonMessageBodyWriter)
+
+    override fun getClasses() = setOf(TestResource::class.java, ErrorMapper::class.java)
+
+}
+
+@Path("users")
+@Produces(MediaType.APPLICATION_JSON)
+class TestResource {
+
+    @GET
+    fun list(): List<User> = testUsersList
+
+    @GET
+    @Path("{id}")
+    fun getById(@PathParam("id") id: Int): User? = testUsersList.find { it.id == id }
+
+    @GET
+    @Path("fail")
+    fun fail(): Nothing = throw UnsupportedOperationException()
+
+}
+
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+class ErrorMapper : ExceptionMapper<Exception> {
+
+    override fun toResponse(exception: Exception): Response = when (exception) {
+        is NotAcceptableException -> exception.response
+        is WebApplicationException -> Response.fromResponse(exception.response)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .entity(ErrorMessage(exception.response.status, exception.localizedMessage))
+                .build()
+        else -> Response.serverError()
+                .entity(ErrorMessage(Response.Status.INTERNAL_SERVER_ERROR.statusCode, exception.localizedMessage))
+                .build()
+    }.also { exception.printStackTrace() }
+
+}
+
+@Serializable
+data class User(val id: Int, val name: String)
+
+@Serializable
+data class ErrorMessage(val errorCode: Int, val message: String?)


### PR DESCRIPTION
Fixes another "masking" issue, when the parameter `genericType` is missing:
```
Caused by: java.lang.IllegalArgumentException: Parameter specified as non-null is null: method com.jakewharton.rs.kotlinx.serialization.StringFormatMessageBodyWriter.isWriteable, parameter genericType
	at com.jakewharton.rs.kotlinx.serialization.StringFormatMessageBodyWriter.isWriteable(KotlinxSerializationMessageBodyWriter.kt)
	at org.jboss.resteasy.core.ResteasyProviderFactoryImpl.resolveMessageBodyWriter(ResteasyProviderFactoryImpl.java:2176)
```

This scenario is triggered in `ReastEasy:4.0.0.Beta8` also, but this time with an `ExceptionMapper`:
![image](https://user-images.githubusercontent.com/513566/56086118-d01af180-5e1d-11e9-930c-3fb21624c38b.png)

I'm not quite sure if assuming `type` in case `genericType` is null is correct, but seems to work well in my project:
`serializerByTypeToken(genericType ?: type)`

Given this simple mapper:
```kotlin
@Provider
class DefaultExceptionMapper : ExceptionMapper<Exception> {

    override fun toResponse(exception: Exception): Response = Response
        .status(exception.statusCode)
        .entity(Error(exception.statusCode, exception.message))
        .header(Headers.CONTENT_TYPE_STRING, MediaType.APPLICATION_JSON)
        .build()
        .also { exception.printStackTrace() }

    private val Exception.statusCode
        get() =
            if (this is HttpResponseException) this.statusCode
            else Response.Status.INTERNAL_SERVER_ERROR.statusCode

    @Serializable
    data class Error(
        val statusCode: Int,
        val message: String? = null
    )

}
```
I'll get the expected response now:
```json
{
"statusCode": 500,
"message": "RESTEASY003210: Could not find resource for full path: http://localhost:8081/api"
}
```